### PR TITLE
Make main file optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Specifying a main JAR or WAR file is no longer required. This allows easy deployment in cases where application startup is managed by a shell script, such as when using [`sbt-native-packager`](https://github.com/sbt/sbt-native-packager). ([#258](https://github.com/heroku/heroku-jvm-application-deployer/pull/258))
 
 ## [4.0.0] - 2023-11-27
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Usage: heroku-jvm-application-deployer [-dhV] [-a=name] [-j=string]
                                        [--jar-opts=options]
                                        [--webapp-runner-version=version] [-b
                                        [=buildpack...]]... [-i[=path...]]...
-                                       file
+                                       [file]
 Application for deploying Java applications to Heroku.
-      file                  The JAR or WAR file to deploy.
+      [file]                The JAR or WAR file to deploy.
   -a, --app=name            The name of the Heroku app to deploy to. Defaults
                               to app name from git remote.
   -b, --buildpack[=buildpack...]

--- a/src/main/java/com/heroku/deployer/Main.java
+++ b/src/main/java/com/heroku/deployer/Main.java
@@ -77,6 +77,8 @@ public class Main implements Callable<Integer> {
                 Path webappRunnerPath = FileDownloader.download(WebappRunnerResolver.getUrlForVersion(webappRunnerVersion));
                 sourceBlobDescriptor.addLocalPath(WEBAPP_RUNNER_SOURCE_BLOB_PATH, webappRunnerPath, false);
             }
+        } else {
+            System.out.printf("-----> No main JAR/WAR file specified, skipping Procfile generation and webapp-runner...\n", webappRunnerVersion);
         }
 
         if (!disableAutoIncludes) {

--- a/src/main/java/com/heroku/deployer/Main.java
+++ b/src/main/java/com/heroku/deployer/Main.java
@@ -23,8 +23,8 @@ import picocli.CommandLine.Parameters;
         description = "Application for deploying Java applications to Heroku.",
         defaultValueProvider = DefaultValueProvider.class)
 public class Main implements Callable<Integer> {
-    @Parameters(index = "0", paramLabel = "file", description = "The JAR or WAR file to deploy.")
-    private Path mainFile;
+    @Parameters(index = "0", arity = "0..1", paramLabel = "file", description = "The JAR or WAR file to deploy.")
+    private Optional<Path> mainFile = Optional.empty();
 
     @Option(names = {"-a", "--app"}, paramLabel = "name", description = "The name of the Heroku app to deploy to. Defaults to app name from git remote.")
     private Optional<String> appName = Optional.empty();
@@ -67,13 +67,16 @@ public class Main implements Callable<Integer> {
         }
 
         SourceBlobDescriptor sourceBlobDescriptor = new SourceBlobDescriptor();
-        includedPaths.add(projectDirectory.resolve(mainFile).normalize());
 
-        Optional<String> mainFileExtension = PathUtils.getFileExtension(mainFile);
-        if (mainFileExtension.isPresent() && mainFileExtension.get().equalsIgnoreCase("war")) {
-            System.out.printf("-----> Downloading webapp-runner %s...\n", webappRunnerVersion);
-            Path webappRunnerPath = FileDownloader.download(WebappRunnerResolver.getUrlForVersion(webappRunnerVersion));
-            sourceBlobDescriptor.addLocalPath(WEBAPP_RUNNER_SOURCE_BLOB_PATH, webappRunnerPath, false);
+        if (mainFile.isPresent()) {
+            includedPaths.add(projectDirectory.resolve(mainFile.get()).normalize());
+
+            Optional<String> mainFileExtension = PathUtils.getFileExtension(mainFile.get());
+            if (mainFileExtension.isPresent() && mainFileExtension.get().equalsIgnoreCase("war")) {
+                System.out.printf("-----> Downloading webapp-runner %s...\n", webappRunnerVersion);
+                Path webappRunnerPath = FileDownloader.download(WebappRunnerResolver.getUrlForVersion(webappRunnerVersion));
+                sourceBlobDescriptor.addLocalPath(WEBAPP_RUNNER_SOURCE_BLOB_PATH, webappRunnerPath, false);
+            }
         }
 
         if (!disableAutoIncludes) {
@@ -181,12 +184,16 @@ public class Main implements Callable<Integer> {
     }
 
     private Optional<Procfile> generateProcfile() {
+        if (!mainFile.isPresent()) {
+            return Optional.empty();
+        }
+
         final Path projectDirectory = Paths.get(System.getProperty("user.dir"));
 
-        return PathUtils.getFileExtension(mainFile).flatMap(extension -> {
+        return PathUtils.getFileExtension(mainFile.get()).flatMap(extension -> {
             // We fall back to an empty string if the path cannot be normalized. This will result in a
             // user-readable error from JvmProjectSourceBlobCreator and the Procfile will never be deployed.
-            String normalizedMainFile = PathUtils.normalize(projectDirectory, mainFile)
+            String normalizedMainFile = PathUtils.normalize(projectDirectory, mainFile.get())
                     .map(PathUtils::separatorsToUnix)
                     .orElse("");
 


### PR DESCRIPTION
## Changelog

* Specifying A main file is no longer required. This allows easy deployment in cases where application startup is managed by a shell script, such as when using [`sbt-native-packager`](https://github.com/sbt/sbt-native-packager).

Ref: GUS-W-14598308