### PR TITLE
Update test fixture for Tomcat `10.1.x`

### DIFF
--- a/integration-test/fixtures/war-app/pom.xml
+++ b/integration-test/fixtures/war-app/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>4.0.4</version>
+      <version>6.0.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/integration-test/fixtures/war-app/src/main/java/com/heroku/HelloWorldServlet.java
+++ b/integration-test/fixtures/war-app/src/main/java/com/heroku/HelloWorldServlet.java
@@ -1,7 +1,7 @@
 package com.heroku;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServlet;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServlet;
 import java.io.IOException;
 
 public class HelloWorldServlet extends HttpServlet {


### PR DESCRIPTION
The existing integration test fixture `war-app` used version `4.0.x` of the Servlet API. This works fine with Tomcat `9.x` but isn't supported by newer Tomcat versions. Since https://github.com/heroku/webapp-runner now supports Tomcat `10.1.x`,  that version will be picked up automatically by `heroku-jvm-application-deployer`, causing the tests to fail.

This PR updates the test fixture to Servlet API `6.0.x`.

Ref: GUS-W-14747550