### PR TITLE
Switch to Cargo.toml based lint configuration

### DIFF
--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -3,6 +3,13 @@ name = "integration-test"
 edition = "2021"
 rust-version = "1.75"
 
+[lints.rust]
+unreachable_pub = "warn"
+unused_crate_dependencies = "warn"
+
+[lints.clippy]
+pedantic = "warn"
+
 [dependencies]
 exponential-backoff = "1"
 fs_extra = "1"

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -1,15 +1,3 @@
-// Enable rustc and Clippy lints that are disabled by default.
-// https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#unused-crate-dependencies
-#![warn(unused_crate_dependencies)]
-// https://rust-lang.github.io/rust-clippy/stable/index.html
-#![warn(clippy::pedantic)]
-// This lint is too noisy and enforces a style that reduces readability in many cases.
-#![allow(clippy::module_name_repetitions)]
-// This lint doesn't make sense in this testing library that is expected to panic as early as
-// possible. Functions are designed to always panic since we don't want to add proper error handling
-// to our tests.
-#![allow(clippy::missing_panics_doc)]
-
 use fs_extra::dir::CopyOptions;
 use libherokubuildpack::command::CommandExt;
 use serde::Deserialize;

--- a/integration-test/tests/integration_tests.rs
+++ b/integration-test/tests/integration_tests.rs
@@ -1,3 +1,6 @@
+// Required due to: https://github.com/rust-lang/rust/issues/95513
+#![allow(unused_crate_dependencies)]
+
 use integration_test::*;
 use std::process::Command;
 


### PR DESCRIPTION
As of the Cargo included in Rust 1.74, lints can now be configured in Cargo.toml across whole crates:
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html
https://doc.rust-lang.org/stable/cargo/reference/manifest.html#the-lints-section

I've also enabled the `unreachable_pub` for parity with our other repos, eg:
https://github.com/heroku/buildpacks-jvm/blob/9c567cafc15206ae8c0cd2aeb2b4cfd171f9589b/Cargo.toml#L18-L26

I've not enabled the various panic/unwrap related lints used in our other repos, since the Rust usage in this repo is purely for tests, for which panicing is expected.

GUS-W-14836332.