### PR TITLE
Use source blob digest when no Git commit SHA is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+* When no Git commit hash is available, the SHA256 sum of the packaged tarball will now be used in its place. Previously, the string `unknown` was used and prevented pipeline promotions due to the same string being used for different versions. ([#281](https://github.com/heroku/heroku-jvm-application-deployer/pull/281))
 
 ## [4.0.1] - 2023-12-05
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
       <version>4.5.14</version>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>

--- a/src/main/java/com/heroku/deployer/Main.java
+++ b/src/main/java/com/heroku/deployer/Main.java
@@ -3,6 +3,7 @@ package com.heroku.deployer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.MessageDigest;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.stream.Stream;
@@ -14,6 +15,7 @@ import com.heroku.deployer.deployment.DeploymentDescriptor;
 import com.heroku.deployer.resolver.WebappRunnerResolver;
 import com.heroku.deployer.sourceblob.SourceBlobDescriptor;
 import com.heroku.deployer.sourceblob.SourceBlobPackager;
+import org.apache.commons.codec.digest.DigestUtils;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -159,13 +161,14 @@ public class Main implements Callable<Integer> {
         }
 
         Path sourceBlobArchive = SourceBlobPackager.pack(sourceBlobDescriptor);
+        String sourceBlobArchiveSha256 = DigestUtils.sha256Hex(Files.newInputStream(sourceBlobArchive));
 
         DeploymentDescriptor deploymentDescriptor = new DeploymentDescriptor(
                 appName.get(),
                 buildpacks,
                 Collections.emptyMap(),
                 sourceBlobArchive,
-                GitUtils.getHeadCommitHash(projectDirectory).orElse("unknown"));
+                GitUtils.getHeadCommitHash(projectDirectory).orElse("nogit-" + sourceBlobArchiveSha256));
 
 
         String version = PropertiesUtils


### PR DESCRIPTION
# Changelog

## Fixed

* When no Git commit hash is available, the SHA256 sum of the packaged tarball will now be used in its place. Previously, the string `unknown` was used and prevented pipeline promotions due to the same string being used for different versions.