### PR TITLE
Fix NPE when Git repository is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Previously, when the working directory contains a Git repository without any commits, `heroku-jvm-application-deployer` crashed with a `NullPointerException`. This case is now handled gracefully. ([#319](https://github.com/heroku/heroku-jvm-application-deployer/pull/319))
 
 ## [4.0.5] - 2024-05-06
 

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -12,7 +12,6 @@ where
 {
     let app_dir = prepare_fixture(fixture_dir);
     initialize_git_repository(&app_dir);
-    create_empty_git_commit(&app_dir);
     let app_create_result = create_heroku_app(&app_dir);
 
     f(TestContext {

--- a/integration-test/tests/integration_tests.rs
+++ b/integration-test/tests/integration_tests.rs
@@ -7,6 +7,8 @@ use std::process::Command;
 #[test]
 fn basic_war_app() {
     prepare_test("war-app", |context| {
+        create_empty_git_commit(&context.app_dir);
+
         run_command(
             Command::new("java")
                 .args([
@@ -32,6 +34,35 @@ fn basic_war_app() {
 #[test]
 fn basic_jar_app() {
     prepare_test("jar-app", |context| {
+        create_empty_git_commit(&context.app_dir);
+
+        run_command(
+            Command::new("java")
+                .args([
+                    "-jar",
+                    &heroku_jvm_application_deployer_jar_path().to_string_lossy(),
+                    &context
+                        .app_dir
+                        .join("target/test-1.0-SNAPSHOT-jar-with-dependencies.jar")
+                        .to_string_lossy(),
+                    "--jdk",
+                    "21",
+                ])
+                .current_dir(&context.app_dir),
+            "Running heroku-jvm-application-deployer failed.",
+            false,
+        );
+
+        let response = http_get_expect_200(&context.app_url);
+        assert_eq!(response, String::from("Hello World!"));
+    });
+}
+
+#[test]
+fn basic_jar_app_git_repo_without_commits() {
+    prepare_test("jar-app", |context| {
+        // Note that no git commit is created
+
         run_command(
             Command::new("java")
                 .args([

--- a/src/main/java/com/heroku/deployer/util/GitUtils.java
+++ b/src/main/java/com/heroku/deployer/util/GitUtils.java
@@ -2,19 +2,17 @@ package com.heroku.deployer.util;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.eclipse.jgit.lib.AnyObjectId;
 import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.ObjectId;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
 public class GitUtils {
     public static Optional<String> getHeadCommitHash(Path projectDirectory) throws IOException {
-        try {
-            Git git = Git.open(projectDirectory.toFile());
-            ObjectId objectId = git.getRepository().resolve(Constants.HEAD);
-            return Optional.of(objectId.getName());
+        try (Git git = Git.open(projectDirectory.toFile())) {
+            return Optional.ofNullable(git.getRepository().resolve(Constants.HEAD))
+                    .map(AnyObjectId::getName);
 
         } catch (RepositoryNotFoundException e) {
             return Optional.empty();


### PR DESCRIPTION
Previously, when the working directory contains a Git repository without any commits, `heroku-jvm-application-deployer` crashed with a `NullPointerException`. This case is now handled gracefully.