### PR TITLE
Use actions/create-github-app-token instead of heroku/use-app-token

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: pub-hk-ubuntu-22.04-small
     steps:
       - name: Get token for GH application (Linguist)
-        uses: heroku/use-app-token-action@main
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,13 +28,13 @@ jobs:
           ref: main
           # Using the GH application token here will configure the local git config for this repo with credentials
           # that can be used to make signed commits that are attributed to the GH application user
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Record latest release version
         id: old-version
         run: echo "version=$(gh release view --json tagName | jq -j '.tagName | sub("v"; "")')" >> "${GITHUB_OUTPUT}"
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Drop -SNAPSHOT suffix from version
         run: ./mvnw versions:set -DremoveSnapshot -DgenerateBackupPoms=false
@@ -60,7 +60,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6.0.5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: Prepare release v${{ steps.new-version.outputs.version }}
           body: |
             Changes:
@@ -75,4 +75,4 @@ jobs:
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,18 +17,18 @@ jobs:
     runs-on: pub-hk-ubuntu-22.04-small
     steps:
       - name: Get token for GH application (Linguist)
-        uses: heroku/use-app-token-action@main
+        uses: actions/create-github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ vars.LINGUIST_GH_APP_ID }}
-          private_key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
+          app-id: ${{ vars.LINGUIST_GH_APP_ID }}
+          private-key: ${{ secrets.LINGUIST_GH_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           # Using the GH application token here will configure the local git config for this repo with credentials
           # that can be used to make signed commits that are attributed to the GH application user
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -53,7 +53,7 @@ jobs:
             exit 1
           fi
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Extract changelog entry
         id: changelog-entry
@@ -75,7 +75,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2.0.5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           tag_name: v${{ steps.new-version.outputs.version }}
           body: ${{ steps.changelog-entry.outputs.content }}
           files: target/heroku-jvm-application-deployer-${{ steps.new-version.outputs.version }}.jar
@@ -91,7 +91,7 @@ jobs:
         id: pr
         uses: peter-evans/create-pull-request@v6.0.5
         with:
-          token: ${{ steps.generate-token.outputs.app_token }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: Prepare next development iteration ${{ steps.next-version.outputs.version }}
           body: |
             Prepare next development iteration `${{ steps.next-version.outputs.version }}`.
@@ -107,4 +107,4 @@ jobs:
         if: steps.pr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash "${{ steps.pr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.app_token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
The use-app-token action is deprecated: https://github.com/heroku/use-app-token-action/pull/17

<img width="1080" alt="334930895-d73c5548-5bd5-4a0b-9102-cad77f556f06" src="https://github.com/heroku/heroku-jvm-application-deployer/assets/27900/606fcc12-fa0c-42d8-97d8-efcc46a4a0ce">

GUS-W-16159735