### PR TITLE
Add missing `--locked` to Cargo commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: "./mvnw --batch-mode package"
       - name: Run integration tests
         working-directory: "integration-test"
-        run: "cargo test"
+        run: "cargo test --locked"
 
   maven:
     name: "Unit Tests (Java ${{ matrix.java-version }})"


### PR DESCRIPTION
The Cargo `--locked` argument ensures that Cargo will fail with an error if `Cargo.lock` is out of sync with `Cargo.toml`, rather than the lockfile being silently updated.

As such, in CI we should always be using `--locked` for projects that have committed their lockfile to Git (which should be the case for most projects other than those that are libraries).

After seeing that `cnb-otel-collector` didn't use `--locked` in all cases, I audited all of our Rust repos and found others missing `--locked` too.

GUS-W-18062544.