### PR TITLE
Run Cargo clippy and fmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,24 @@ jobs:
         working-directory: "integration-test"
         run: "cargo test --locked"
 
+  rust-lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Update Rust toolchain
+        run: rustup update
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2.7.7
+        with:
+          workspaces: "./integration-test"
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features --locked -- --deny warnings
+        working-directory: integration-test
+      - name: rustfmt
+        run: cargo fmt -- --check
+        working-directory: integration-test
+
   maven:
     name: "Unit Tests (Java ${{ matrix.java-version }})"
     runs-on: ubuntu-24.04

--- a/integration-test/Cargo.toml
+++ b/integration-test/Cargo.toml
@@ -8,7 +8,8 @@ unreachable_pub = "warn"
 unused_crate_dependencies = "warn"
 
 [lints.clippy]
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
+missing_panics_doc = "allow"
 
 [dependencies]
 exponential-backoff = "2"

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -43,6 +43,7 @@ pub fn heroku_jvm_application_deployer_jar_path() -> PathBuf {
         let dir_entry = dir_entry.unwrap();
         let file_name = dir_entry.file_name().to_string_lossy().into_owned();
 
+        #[allow(clippy::case_sensitive_file_extension_comparisons)]
         if file_name.starts_with("heroku-jvm-application-deployer") && file_name.ends_with(".jar") {
             return dir_entry.path();
         }
@@ -171,7 +172,6 @@ where
             result @ Err(_) => match backoff_durations.next() {
                 Some(Some(backoff_duration)) => {
                     std::thread::sleep(backoff_duration);
-                    continue;
                 }
                 _ => return result,
             },


### PR DESCRIPTION
Since we should always be running these in CI for all projects that use Rust.

The job was copied from that run here:
https://github.com/heroku/heroku-java-metrics-agent/blob/86dd6bf68d3cafdecbc0b281f2a4f54a00c41371/.github/workflows/ci.yml#L82-L98

GUS-W-18062768.