### PR TITLE
Clarify description for args with arity = *

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Help description for the `-b` and `-i` command line arguments to explicitly state that they can be passed multiple times. ([#401](https://github.com/heroku/heroku-jvm-application-deployer/pull/401))
 
 ## [4.0.8] - 2025-01-07
 

--- a/README.md
+++ b/README.md
@@ -41,18 +41,21 @@ Application for deploying Java applications to Heroku.
   -a, --app=name            The name of the Heroku app to deploy to. Defaults
                               to app name from git remote.
   -b, --buildpack[=buildpack...]
-                            Defaults to heroku/jvm.
+                            Defaults to heroku/jvm, can be passed multiple
+                              times to use multiple buildpacks.
   -d, --disable-auto-includes
                             Disable automatic inclusion of certain files.
   -h, --help                Show this help message and exit.
-  -i, --include[=path...]   Additional files or directories to include.
+  -i, --include[=path...]   Additional files or directories to include, can be
+                              passed multiple times to include multiple files
+                              and directories.
   -j, --jdk=string          Set the Heroku JDK selection string for the app (i.
                               e. 17, 21.0.1).
       --jar-opts=options    Add command line options for when the JAR is run.
   -V, --version             Print version information and exit.
       --webapp-runner-version=version
                             The version of webapp-runner to use. Defaults to
-                              the most recent version (9.0.83.0).
+                              the most recent version (10.1.41.0).
 ```
 
 ## Requirements

--- a/src/main/java/com/heroku/deployer/Main.java
+++ b/src/main/java/com/heroku/deployer/Main.java
@@ -33,7 +33,7 @@ public class Main implements Callable<Integer> {
     @Option(names = {"-a", "--app"}, paramLabel = "name", description = "The name of the Heroku app to deploy to. Defaults to app name from git remote.")
     private Optional<String> appName = Optional.empty();
 
-    @Option(names = {"-b", "--buildpack"}, arity = "*", paramLabel = "buildpack", defaultValue = "heroku/jvm", description = "Defaults to ${DEFAULT-VALUE}.")
+    @Option(names = {"-b", "--buildpack"}, arity = "*", paramLabel = "buildpack", defaultValue = "heroku/jvm", description = "Defaults to ${DEFAULT-VALUE}, can be passed multiple times to use multiple buildpacks.")
     private List<String> buildpacks = new ArrayList<>();
 
     @Option(names = {"--webapp-runner-version"}, paramLabel = "version", description = "The version of webapp-runner to use. Defaults to the most recent version (${DEFAULT-VALUE}).")
@@ -48,7 +48,7 @@ public class Main implements Callable<Integer> {
     @Option(names = {"-d", "--disable-auto-includes"}, description = "Disable automatic inclusion of certain files.", defaultValue = "false")
     private boolean disableAutoIncludes = false;
 
-    @Option(names = {"-i", "--include"}, arity = "*", paramLabel = "path", description = "Additional files or directories to include.")
+    @Option(names = {"-i", "--include"}, arity = "*", paramLabel = "path", description = "Additional files or directories to include, can be passed multiple times to include multiple files and directories.")
     private List<Path> includedPaths = new ArrayList<>();
 
     @Override


### PR DESCRIPTION
It's not immediately clear that those arguments can be passed multiple times to add values instead of overriding a single one.

GUS-W-18736194.

## Changelog
### Changed

* Help description for the `-b` and `-i` command line arguments to explicitly state that they can be passed multiple times. ([#401](https://github.com/heroku/heroku-jvm-application-deployer/pull/401))