### PR TITLE
Deploy to Central Publishing Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '11'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_CENTRAL_USERNAME
-          server-password: MAVEN_CENTRAL_TOKEN
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,13 +18,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-  </distributionManagement>
-
   <licenses>
     <license>
       <name>MIT</name>
@@ -191,14 +184,13 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.7.0</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
         <extensions>true</extensions>
         <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>true</autoPublish>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
As of June 30, 2025 OSSRH has reached end of life and has been shut down. All OSSRH namespaces have been migrated to Central Publisher Portal.

This PR updates the release automation and Maven deploy configuration to use the new Central Publishing Portal API directly. We will not use the [OSSRH staging api](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) which is a compatibility layer.

For users of this tool, nothing changes.

GUS-W-18961471